### PR TITLE
[CD-15900] memory crash fix

### DIFF
--- a/lib/svg2geojson.js
+++ b/lib/svg2geojson.js
@@ -76,21 +76,23 @@ function convertSVGToGeoJSON(doc, options = {}) {
 	})
 
 	for (var name in layerByName) {
-		if (!layerByName[name].length) continue
-		const geo = {
-			type: 'FeatureCollection',
-			creator: `svg2geojson v${pkg.version}`,
-			features: layerByName[name].map((data) => {
-				var obj = {
-					type: 'Feature',
-					properties: data.properties ? data.properties : {},
-					geometry: data,
-				}
-				delete data.properties
-				return obj
-			}),
-		}
-		layers.push({ name: name, geo: geo })
+    if (layerByName[name].length) {
+      const geo = {
+        type: 'FeatureCollection',
+        creator: `svg2geojson v${pkg.version}`,
+        features: layerByName[name].map((data) => {
+          var obj = {
+            type: 'Feature',
+            properties: data.properties ? data.properties : {},
+            geometry: data,
+          }
+          delete data.properties
+          return obj
+        }),
+      }
+      layers.push({ name: name, geo: geo })
+    } 
+    delete layerByName[name];
 	}
 
 	return options.layers ? layers : layers[0].geo


### PR DESCRIPTION
- delete layerByName object property after each iteration
- using `-minimal` flag when calling `svg2geojson` is fixed [here](https://gitlab.com/BuildingRobotics/geoservice/-/merge_requests/44)


----
memory usage using `OG4.svg` (file size: 1.8MB)

JS Heap
- before any fixes: 1400MB and then crash
- using -minimal argument for svg2geojson: successful with 682MB heap
- -minimal + delete layerByName[name] fix: successful with 245MB heap, peaked at 407MB
- -minimal + delete layerByName[name] fix + use JSON.stringify instead of neatJSON: successful with 200MB but with resulting .geojson file size of 25.9MB instead of 18MB



memory usage using `bmw2.svg` (file size: 5MB) 
- with fix: Successful with 573MB heap, 16.4MB geojson file
- with fix + JSON.stringify: successful with 315MB heap, 18.8MB geojson file (weird! neatJSON is supposed to reduce the size)

